### PR TITLE
Use Filebeat version 6, bugfix for ca paths

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -22,7 +22,7 @@
   file:
     path: "{{ filebeat_ssl_dir }}"
     state: directory
-  when: filebeat_ssl_key_file
+  when: filebeat_ssl_key_file is defined and filebeat_ssl_key_file != ''
 
 - name: Copy SSL key and cert for filebeat.
   copy:
@@ -33,7 +33,9 @@
     - "{{ filebeat_ssl_key_file }}"
     - "{{ filebeat_ssl_certificate_file }}"
   notify: restart filebeat
-  when: filebeat_ssl_key_file and filebeat_ssl_certificate_file
+  when:
+    - filebeat_ssl_key_file is defined and filebeat_ssl_key_file != ''
+    - filebeat_ssl_certificate_file is defined and filebeat_ssl_certificate_file != ''
 
 - name: Ensure Filebeat CA directory exists.
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install Filebeat.
-  package: name=filebeat state=present
+  package: name=filebeat state=latest
 
 - include: config.yml
   when: filebeat_create_config

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -9,6 +9,6 @@
 
 - name: Add Filebeat repository.
   apt_repository:
-    repo: 'deb https://artifacts.elastic.co/packages/5.x/apt stable main'
+    repo: 'deb https://artifacts.elastic.co/packages/6.x/apt stable main'
     state: present
     update_cache: yes

--- a/templates/beats.repo.j2
+++ b/templates/beats.repo.j2
@@ -1,6 +1,6 @@
 [elastic-5.x]
 name=Elastic repository for 5.x packages
-baseurl=https://artifacts.elastic.co/packages/5.x/yum
+baseurl=https://artifacts.elastic.co/packages/6.x/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -61,7 +61,7 @@ output:
     ssl:
       enabled: true
       # List of root certificates for HTTPS server verifications
-      {% if filebeat_ssl_ca %}
+{% if filebeat_ssl_ca %}
         certificate_authorities: {{ [filebeat_ssl_ca_dir + "/"] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
       {% endif %}
 
@@ -69,7 +69,7 @@ output:
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
 
       # Client Certificate Key
-      certificate_key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+      key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
 
       # Controls whether the client verifies server certificates and host name.
       # If insecure is set to true, all server host names and certificates will be
@@ -113,7 +113,7 @@ output:
     ssl:
       enabled: true
       # List of root certificates for HTTPS server verifications
-      {% if filebeat_ssl_ca %}
+{% if filebeat_ssl_ca %}
         certificate_authorities: {{ [filebeat_ssl_ca_dir + "/"] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
       {% endif %}
 
@@ -121,7 +121,7 @@ output:
       certificate: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_certificate_file | basename }}"
 
       # Client Certificate Key
-      certificate_key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
+      key: "{{ filebeat_ssl_dir }}/{{ filebeat_ssl_key_file | basename}}"
 
       # Controls whether the client verifies server certificates and host name.
       # If insecure is set to true, all server host names and certificates will be

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -58,10 +58,11 @@ output:
 
 {% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
     # tls configuration. By default is off.
-    tls:
+    ssl:
+      enabled: true
       # List of root certificates for HTTPS server verifications
       {% if filebeat_ssl_ca %}
-        certificate_authorities: {{ [filebeat_ssl_ca_dir] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
+        certificate_authorities: {{ [filebeat_ssl_ca_dir + "/"] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
       {% endif %}
 
       # Certificate for TLS client authentication
@@ -109,10 +110,11 @@ output:
 
 {% if filebeat_ssl_certificate_file and filebeat_ssl_key_file %}
     # Optional TLS. By default is off.
-    tls:
+    ssl:
+      enabled: true
       # List of root certificates for HTTPS server verifications
       {% if filebeat_ssl_ca %}
-        certificate_authorities: {{ [filebeat_ssl_ca_dir] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
+        certificate_authorities: {{ [filebeat_ssl_ca_dir + "/"] | zip_longest(filebeat_ssl_ca_basenames, fillvalue=filebeat_ssl_ca_dir) | map('join') | list | to_json }}
       {% endif %}
 
       # Certificate for TLS client authentication


### PR DESCRIPTION
Before, paths creation was inconsistent, the path to logstash CA before MR was `/etc/pki/logstash/caca.pem`, as even default value of `filebeat_ssl_ca_dir` did not have a closing slash